### PR TITLE
Reorganize gitignore files for frontend and backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,78 @@
-test-results
-node_modules
+# Created by https://www.toptal.com/developers/gitignore/api/macos,linux,windows
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,linux,windows
 
-# Output
-.output
-.vercel
-.netlify
-.wrangler
-.svelte-kit
-/build
+### Linux ###
+*~
 
-# OS
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
 .DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### Windows ###
+# Windows thumbnail cache files
 Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
 
-# Env
-.env
-.env.*
-!.env.example
-!.env.test
+# Dump file
+*.stackdump
 
-# Vite
-vite.config.js.timestamp-*
-vite.config.ts.timestamp-*
+# Folder config file
+[Dd]esktop.ini
 
-# Backend
-__pycache__/
-.venv
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,linux,windows

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,3 @@
+# Backend
+__pycache__/
+.venv

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,24 @@
+test-results
+node_modules
+
+# Output
+.output
+.vercel
+.netlify
+.wrangler
+/.svelte-kit
+/build
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Env
+.env
+.env.*
+!.env.example
+!.env.test
+
+# Vite
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*


### PR DESCRIPTION
Since we have a Python Backend and a TypeScript Frontend, having separate `.gitignore` for each directory helps with housekeeping.

Separates project-specific ignores into frontend/ and backend/ directories while adding comprehensive OS-specific ignores to root .gitignore

Reference:
- https://stackoverflow.com/questions/9730486/can-you-have-additional-gitignore-per-directory-within-a-single-repo