### PR TITLE
chore: update .npmrc to include minimum release age setting

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+minimum-release-age=20160


### PR DESCRIPTION
## PR Summary
Adds minimum-release-age=20160 to .npmrc to delay dependency updates by 2 weeks (20,160 minutes) to reduce supply chain risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm configuration settings for the frontend environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->