### PR TITLE
Fix: pnpm not found error when commiting from IDE

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,13 @@ repos:
     hooks:
       - id: frontend-format
         name: Frontend Format (Prettier)
-        entry: bash -c 'cd frontend && pnpm run format'
+        entry: bash -ic 'cd frontend && pnpm run format'
         language: system
         files: ^frontend/.*\.(js|ts|svelte|css|json|html)$
 
       - id: frontend-lint
         name: Frontend Lint (ESLint)
-        entry: bash -c 'cd frontend && pnpm run lint'
+        entry: bash -ic 'cd frontend && pnpm run lint'
         language: system
         files: ^frontend/.*\.(js|ts|svelte)$
 


### PR DESCRIPTION
Using `-i` (interactive) flag for bash ensures that login-shell initialization files (`.bashrc`) are sourced, which is necessary to initialize `fnm` (in my case) and for `pnpm` to be correctly recognized.

The error: 
<img width="1307" height="692" alt="Screenshot 2025-12-14 082109" src="https://github.com/user-attachments/assets/6a44c0be-ecde-4bb4-ae4c-fc296eb43dd1" />