### PR TITLE
chore: reposition SuperImpress around carousel MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ SuperImpress is a [Frontend Hire](https://www.frontendhire.com/) initiative wher
 
 This is why I am (or hopefully, we are) building SuperImpress.
 
-There are many LinkedIn tools out there but:
+There are many content tools out there but:
 
-- They make excessive use of AI to create content.
-- This automatically results in not-so-authentic content.
-- In order to sell themselves, they are marketing writing on LinkedIn in a wrong way.
+- They over-automate the thinking and under-serve the storytelling.
+- They turn source material into generic slide decks instead of sharp carousel narratives.
+- They often make it harder to turn strong long-form thinking into simple visual content.
 
 SuperImpress will:
 
-- Be author first and AI second.
-- You write, then if needed you use AI to fix the writing.
-- Give you templates that are plagiarism safe.
-- And more, as I myself use the product.
+- Turn pasted content into minimal-text carousels.
+- Be author first and AI assisted, using the source material instead of inventing fluff.
+- Break ideas into clear slide-by-slide stories with visualization notes.
+- Stay intentionally narrow so the workflow feels fast and useful.
 
 ---
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: SuperImpress
-description: Documentation for SuperImpress - a personal brand building tool
+description: Documentation for SuperImpress - a minimal-text carousel generation tool
 ---
 
-SuperImpress is a personal brand building tool focused on writing and scheduling posts to social platforms. It provides a minimal interface to help you write consistently and reach your audience without the complexity of other tools.
+SuperImpress is a carousel creation tool focused on turning pasted content into minimal-text, slide-by-slide drafts. It is designed to help creators turn dense ideas into clear visual storytelling without falling into generic AI output.
 
 ## Product Decisions
 
-These documents explain the motivation, vision, and scope of SuperImpress.
+These documents explain the motivation, vision, and scope of SuperImpress as a carousel-first product.
 
 <Cards>
   <Card title="Why" href="/product/1-why" description="The motivation behind building SuperImpress" />

--- a/docs/content/docs/product/1-why.mdx
+++ b/docs/content/docs/product/1-why.mdx
@@ -3,5 +3,7 @@ title: Why
 description: The motivation behind building SuperImpress
 ---
 
-- I want to write and reach folks and build out a personal brand.
-- I know writing and sharing consistently helps but most tools out there have become either overcomplicated or an AI-slop.
+- I want to turn strong ideas into visual content that people will actually stop and read.
+- Breaking long-form thinking into carousel slides manually is slow, repetitive, and mentally expensive.
+- Most AI content tools optimize for volume, which usually leads to generic slides and weak storytelling.
+- I want a tool that starts from my words, finds the structure, and helps me publish sharper carousel narratives.

--- a/docs/content/docs/product/2-what.mdx
+++ b/docs/content/docs/product/2-what.mdx
@@ -3,4 +3,6 @@ title: What
 description: What SuperImpress aims to be
 ---
 
-- A product with minimal interface to write and schedule.
+- A focused product that turns pasted content into minimal-text carousels.
+- A workflow that helps creators break one dense idea into a clear sequence of up to 10 slides.
+- A tool that generates slide copy and visualization notes, while still leaving the author in control of the final output.

--- a/docs/content/docs/product/3-how.mdx
+++ b/docs/content/docs/product/3-how.mdx
@@ -3,5 +3,7 @@ title: How
 description: The technical approach to building SuperImpress
 ---
 
-- A simple CRUD app to first store the posts.
-- A simple scheduler to post them to specific social platforms.
+- Accept pasted text of any length as the source material.
+- Use an AI model to identify the strongest narrative arc and decide how minimal each slide should be.
+- Generate a structured carousel draft with slide roles, short copy, and visualization notes.
+- Let the user edit slides, reorder them, regenerate individual slides, and export the draft for design/publishing elsewhere.

--- a/docs/content/docs/product/4-mvp.mdx
+++ b/docs/content/docs/product/4-mvp.mdx
@@ -3,6 +3,9 @@ title: MVP
 description: Minimum viable product scope for SuperImpress
 ---
 
-- Create a Post
-- Save a Post
-- Schedule a Post to `LinkedIn`
+- Paste content of any length
+- Choose the audience, tone, and desired outcome
+- Generate a minimal-text carousel draft with a maximum of 10 slides
+- Include a visualization note for every slide
+- Edit slide text, reorder slides, and regenerate a single slide
+- Copy the carousel text and visualization notes for downstream design/publishing

--- a/marketing-site/src/app/layout.tsx
+++ b/marketing-site/src/app/layout.tsx
@@ -16,17 +16,17 @@ const displayFont = Playfair_Display({
 export const metadata: Metadata = {
   metadataBase: new URL("https://superimpress.com"),
   title: {
-    default: "SuperImpress | Human-first LinkedIn Writing and Scheduling",
+    default: "SuperImpress | Minimal-Text Carousel Generation",
     template: "%s | SuperImpress",
   },
   description:
-    "SuperImpress helps LinkedIn creators write consistently with a minimal, author-first workflow.",
+    "SuperImpress helps creators turn pasted content into minimal-text carousel drafts with stronger sequencing and visual cues.",
   alternates: {
     canonical: "/",
   },
   openGraph: {
     description:
-      "A minimal interface to write, save, and schedule LinkedIn posts without bloated workflows.",
+      "Generate slide-by-slide carousel drafts from any pasted content without bloated content workflows.",
     siteName: "SuperImpress",
     title: "SuperImpress",
     type: "website",
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     description:
-      "Author-first LinkedIn writing and scheduling with a clean, minimal workflow.",
+      "Minimal-text carousel generation for creators who want sharper visual storytelling.",
     title: "SuperImpress",
   },
 };

--- a/marketing-site/src/app/page.tsx
+++ b/marketing-site/src/app/page.tsx
@@ -90,7 +90,8 @@ export default function Home() {
             <Reveal>
               <p className="eyebrow">Why SuperImpress</p>
               <h2 className="section-title mt-3 max-w-2xl">
-                For LinkedIn creators who want consistency without noise.
+                For creators who want carousel storytelling without bloated
+                tooling.
               </h2>
             </Reveal>
             <div className="mt-8 grid gap-4 md:grid-cols-3">
@@ -110,7 +111,7 @@ export default function Home() {
             <Reveal>
               <p className="eyebrow">How It Works</p>
               <h2 className="section-title mt-3 max-w-2xl">
-                A straightforward path from draft to published post.
+                A straightforward path from raw content to a carousel draft.
               </h2>
             </Reveal>
             <div className="mt-8 grid gap-4 md:grid-cols-3">
@@ -159,7 +160,7 @@ export default function Home() {
             <Reveal>
               <p className="eyebrow">Principles</p>
               <h2 className="section-title mt-3 max-w-2xl">
-                Product choices grounded in real writing workflows.
+                Product choices grounded in real content breakdown workflows.
               </h2>
             </Reveal>
             <div className="mt-8 grid gap-4 md:grid-cols-3">
@@ -208,7 +209,7 @@ export default function Home() {
               <div className="surface-card p-7 sm:p-10">
                 <p className="eyebrow">Community</p>
                 <h2 className="section-title mt-3 max-w-2xl">
-                  Join other LinkedIn creators.
+                  Join other creators shaping the product.
                 </h2>
                 <div className="mt-7 flex flex-wrap items-center gap-3">
                   <a

--- a/marketing-site/src/lib/site-config.ts
+++ b/marketing-site/src/lib/site-config.ts
@@ -41,7 +41,7 @@ interface SiteConfig {
 export const siteConfig: SiteConfig = {
   brand: "SuperImpress",
   description:
-    "Human-first LinkedIn writing and scheduling, without the clutter of traditional growth tools.",
+    "Turn any pasted content into a minimal-text carousel draft with sharp sequencing and visual cues.",
   discordUrl: "https://discord.gg/DWAVqksVtx",
   docsUrl: "https://docs.superimpress.com",
   faq: [
@@ -52,13 +52,13 @@ export const siteConfig: SiteConfig = {
     },
     {
       answer:
-        "The current MVP focuses on LinkedIn so we can keep the experience simple and reliable.",
-      question: "Which platforms are supported today?",
+        "The MVP focuses on carousel generation only: paste content, generate a slide-by-slide draft, edit it, and export the copy with visualization notes.",
+      question: "What does the MVP do today?",
     },
     {
       answer:
-        "Yes. You can still draft and organize your posts, and mark them as published manually when needed.",
-      question: "Can I use it without connecting social accounts?",
+        "Yes. The first version does not require social account connections because it is focused on carousel creation, not publishing.",
+      question: "Do I need to connect social accounts?",
     },
   ],
   footerLinks: [
@@ -66,14 +66,19 @@ export const siteConfig: SiteConfig = {
     { href: "https://discord.gg/DWAVqksVtx", label: "Discord" },
   ],
   hero: {
-    chips: ["Author-first", "LinkedIn scheduling", "Minimal interface"],
+    chips: ["Carousel-first", "Minimal text", "Visual storytelling"],
     subtitle:
-      "Write in your own voice, save drafts quickly, and schedule without wrestling with bloated workflows.",
-    title:
-      "Write consistently on LinkedIn with a tool that stays out of your way.",
+      "Paste dense source content, get a cleaner 6-10 slide narrative with short copy and visualization notes.",
+    title: "Turn any idea into a minimal-text carousel that feels deliberate.",
   },
   launchNote: "Limited early-access seats open in small batches.",
-  mvpItems: ["Create a post", "Save a post", "Schedule to LinkedIn"],
+  mvpItems: [
+    "Paste content of any length",
+    "Generate up to 10 carousel slides",
+    "Get text plus visualization notes",
+    "Edit, reorder, and regenerate slides",
+    "Copy the draft for downstream design and publishing",
+  ],
   navItems: [
     { href: "#why", label: "Why" },
     { href: "#how", label: "How" },
@@ -83,41 +88,40 @@ export const siteConfig: SiteConfig = {
   principles: [
     {
       description:
-        "You write first. AI should help refine your voice, not replace it.",
-      title: "Author first, AI second",
+        "The source material drives the output. AI should structure and compress ideas, not fabricate them.",
+      title: "Source first, AI assisted",
     },
     {
       description:
-        "Every screen and workflow is designed for clarity, not feature sprawl.",
-      title: "Minimal by design",
+        "Each slide should earn attention with very little text and a clear role in the narrative.",
+      title: "Minimal text, sharp flow",
     },
     {
       description:
-        "Publish directly or track manually. Keep your workflow private and flexible.",
-      title: "Flexible publishing",
+        "The product stops at a strong draft so creators can keep their design and publishing workflows flexible.",
+      title: "Draft, then design anywhere",
     },
   ],
   steps: [
     {
       description:
-        "Capture ideas and drafts with a straightforward editor focused on writing flow.",
-      title: "Write",
+        "Paste the raw source material, whether it is a rough note, article, transcript, or long-form draft.",
+      title: "Paste",
     },
     {
       description:
-        "Queue posts for LinkedIn with a simple schedule, no unnecessary setup.",
-      title: "Schedule",
+        "Set the audience, tone, and desired outcome so the carousel aims at the right reader response.",
+      title: "Direct",
     },
     {
       description:
-        "Publish through supported flows or mark a post as published and track the live link manually.",
-      title: "Publish / Track",
+        "Get a structured carousel draft with short slide copy and visualization notes you can refine and export.",
+      title: "Generate",
     },
   ],
-
   whyPoints: [
-    "Most LinkedIn tools are overcomplicated and distracting.",
-    "AI-first flows often push generic, inauthentic writing.",
-    "Consistency drops when posting takes too many steps.",
+    "Turning long-form content into a good carousel still takes too many manual decisions.",
+    "Most AI outputs read like stuffed captions split into slides, not actual carousel storytelling.",
+    "Creators need help compressing ideas into a cleaner visual sequence, not another bloated content suite.",
   ],
 };


### PR DESCRIPTION
## Summary
- reposition the repo docs and README around SuperImpress as a minimal-text carousel generator
- refresh the marketing site hero, FAQ, principles, MVP, and metadata to match the carousel-first product direction
- replace the previous LinkedIn writing/scheduling messaging with source-first carousel storytelling language